### PR TITLE
Drop the old versions of the ppp extension

### DIFF
--- a/build/extensions.json
+++ b/build/extensions.json
@@ -226,7 +226,7 @@
       "name": {
         "en": "OCDS for PPPs Extension"
       },
-      "url": "https://raw.githubusercontent.com/open-contracting-extensions/ocds_ppp_extension/v1.1.3/"
+      "url": "https://raw.githubusercontent.com/open-contracting-extensions/ocds_ppp_extension/master/"
     },
     {
       "category": "release",

--- a/extension_versions.csv
+++ b/extension_versions.csv
@@ -39,7 +39,6 @@ participation_fee,2018-01-30,v1.1.3,https://raw.githubusercontent.com/open-contr
 partyScale,,master,https://raw.githubusercontent.com/open-contracting/ocds_partyDetails_scale_extension/master/,https://github.com/open-contracting/ocds_partyDetails_scale_extension/archive/master.zip
 performance_failures,,master,https://raw.githubusercontent.com/open-contracting/ocds_performance_failures/master/,https://github.com/open-contracting/ocds_performance_failures/archive/master.zip
 ppp,,master,https://raw.githubusercontent.com/open-contracting-extensions/ocds_ppp_extension/master/,https://github.com/open-contracting-extensions/ocds_ppp_extension/archive/master.zip
-ppp,2018-06-26,v1.1.3,https://raw.githubusercontent.com/open-contracting-extensions/ocds_ppp_extension/v1.1.3/,https://api.github.com/repos/open-contracting-extensions/ocds_ppp_extension/zipball/v1.1.3
 process_title,,master,https://raw.githubusercontent.com/open-contracting/ocds_process_title_extension/master/,https://github.com/open-contracting/ocds_process_title_extension/archive/master.zip
 process_title,2017-05-09,v1.1,https://raw.githubusercontent.com/open-contracting/ocds_process_title_extension/v1.1/,https://api.github.com/repos/open-contracting/ocds_process_title_extension/zipball/v1.1
 process_title,2017-08-07,v1.1.1,https://raw.githubusercontent.com/open-contracting/ocds_process_title_extension/v1.1.1/,https://api.github.com/repos/open-contracting/ocds_process_title_extension/zipball/v1.1.1

--- a/extension_versions.csv
+++ b/extension_versions.csv
@@ -39,8 +39,6 @@ participation_fee,2018-01-30,v1.1.3,https://raw.githubusercontent.com/open-contr
 partyScale,,master,https://raw.githubusercontent.com/open-contracting/ocds_partyDetails_scale_extension/master/,https://github.com/open-contracting/ocds_partyDetails_scale_extension/archive/master.zip
 performance_failures,,master,https://raw.githubusercontent.com/open-contracting/ocds_performance_failures/master/,https://github.com/open-contracting/ocds_performance_failures/archive/master.zip
 ppp,,master,https://raw.githubusercontent.com/open-contracting-extensions/ocds_ppp_extension/master/,https://github.com/open-contracting-extensions/ocds_ppp_extension/archive/master.zip
-ppp,2017-05-09,v1.1,https://raw.githubusercontent.com/open-contracting/public-private-partnerships/v1.1/,https://api.github.com/repos/open-contracting/public-private-partnerships/zipball/v1.1
-ppp,2017-08-07,v1.1.1,https://raw.githubusercontent.com/open-contracting/public-private-partnerships/v1.1.1/,https://api.github.com/repos/open-contracting/public-private-partnerships/zipball/v1.1.1
 ppp,2018-06-26,v1.1.3,https://raw.githubusercontent.com/open-contracting-extensions/ocds_ppp_extension/v1.1.3/,https://api.github.com/repos/open-contracting-extensions/ocds_ppp_extension/zipball/v1.1.3
 process_title,,master,https://raw.githubusercontent.com/open-contracting/ocds_process_title_extension/master/,https://github.com/open-contracting/ocds_process_title_extension/archive/master.zip
 process_title,2017-05-09,v1.1,https://raw.githubusercontent.com/open-contracting/ocds_process_title_extension/v1.1/,https://api.github.com/repos/open-contracting/ocds_process_title_extension/zipball/v1.1


### PR DESCRIPTION
These were once distributed by the https://github.com/open-contracting/public-private-partnerships repo, but that repo now distributes the OCDS for PPPs consolidated extension. Having tags within one repo for two extensions is sure to cause confusion (I recently deleted the tags as a result of such confusion). There is no special need to have old versions of this extension in the registry, so it's okay to remove these lines.